### PR TITLE
Merge Functionality

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -169,6 +169,13 @@ func (g *Graph) All(s Term, p Term, o Term) []*Triple {
 	return triples
 }
 
+// Merge is used to add all the triples form another graph to this one
+func (g *Graph) Merge(toMerge *Graph){
+	for triple := range toMerge.IterTriples(){
+		g.Add(triple)
+	}
+}
+
 // Parse is used to parse RDF data from a reader, using the provided mime type
 func (g *Graph) Parse(reader io.Reader, mime string) error {
 	parserName := mimeParser[mime]

--- a/graph_test.go
+++ b/graph_test.go
@@ -208,3 +208,25 @@ func TestSerializeJSONLD(t *testing.T) {
 	g2.Parse(toParse, "application/ld+json")
 	assert.Equal(t, 3, g2.Len())
 }
+
+func TestGraphMerge(t *testing.T) {
+	g := NewGraph(testUri)
+	g2 := NewGraph(testUri)
+
+	g.AddTriple(NewResource("a"), NewResource("b"), NewResource("c"))
+	g.AddTriple(NewResource("a"), NewResource("b"), NewResource("d"))
+	g.AddTriple(NewResource("a"), NewResource("f"), NewLiteral("h"))
+	assert.Equal(t,3,g.Len())
+	g2.AddTriple(NewResource("g"), NewResource("b2"), NewResource("e"))
+	g2.AddTriple(NewResource("g"), NewResource("b2"), NewResource("c"))
+	assert.Equal(t,2,g2.Len())
+
+	g.Merge(g2)
+
+	assert.Equal(t,5,g.Len())
+    assert.NotEqual(t,nil,g.One(NewResource("a"),NewResource("b"),NewResource("c")))
+	assert.NotEqual(t,nil,g.One(NewResource("a"),NewResource("b"),NewResource("d")))
+	assert.NotEqual(t,nil,g.One(NewResource("a"),NewResource("f"),NewResource("h")))
+	assert.NotEqual(t,nil,g.One(NewResource("g"),NewResource("b2"),NewResource("e")))
+	assert.NotEqual(t,nil,g.One(NewResource("g"),NewResource("b2"),NewResource("c")))
+}


### PR DESCRIPTION
Needed this for a personal project, so I thought I'd give it back. I was not sure about what to do with triples that already exist in the graph, so I didn't do anything.

If I understood the library correctly, by creating a:

```go
map[*triple]bool
```

if we:

```go
t := NewTriple(NewResource("a"),NewResource("b"),NewResource("c"))
graph.Add(t)
graph.Add(t)
```

Thats fine, because `&t` is the same in the 2 calls to Add, but if we:

```go
graph.AddTriple(NewResource("a"),NewResource("b"),NewResource("c"))
graph.AddTriple(NewResource("a"),NewResource("b"),NewResource("c"))
```

The first AddTriple will create a *Triple which will be used as a key in the map, but so will the second one, essentially putting the same triple twice in the same graph.

~~Is this assumption wrong? I did not test it, I only thought about it after pushing...~~

I have tested, my assumption is correct, but I do realise it's out of the scope of this pull request