### PR TITLE
Fix for Bnode subject serialization for JSON-LD.

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -314,8 +314,16 @@ func (g *Graph) serializeTurtle(w io.Writer) error {
 func (g *Graph) serializeJSONLD(w io.Writer) error {
 	r := []map[string]interface{}{}
 	for elt := range g.IterTriples() {
-		one := map[string]interface{}{
-			"@id": elt.Subject.(*Resource).URI,
+		var one map[string]interface{}
+		switch elt.Subject.(type) {
+		case *BlankNode:
+			one = map[string]interface{}{
+				"@id": elt.Subject.(*BlankNode).String(),
+			}
+		default:
+			one = map[string]interface{}{
+				"@id": elt.Subject.(*Resource).URI,
+			}
 		}
 		switch t := elt.Object.(type) {
 		case *Resource:

--- a/graph_test.go
+++ b/graph_test.go
@@ -199,12 +199,13 @@ func TestSerializeJSONLD(t *testing.T) {
 	g := NewGraph(testUri)
 	g.Parse(strings.NewReader(simpleTurtle), "text/turtle")
 	g.Add(NewTriple(NewResource(testUri+"#me"), NewResource("http://xmlns.com/foaf/0.1/nick"), NewLiteralWithLanguage("test", "en")))
-	assert.Equal(t, 3, g.Len())
+	g.Add(NewTriple(NewBlankNode(9), NewResource("http://xmlns.com/foaf/0.1/name"), NewLiteralWithLanguage("test", "en")))
+	assert.Equal(t, 4, g.Len())
 
 	var b bytes.Buffer
 	g.Serialize(&b, "application/ld+json")
 	toParse := strings.NewReader(b.String())
 	g2 := NewGraph(testUri)
 	g2.Parse(toParse, "application/ld+json")
-	assert.Equal(t, 3, g2.Len())
+	assert.Equal(t, 4, g2.Len())
 }


### PR DESCRIPTION
A panic was thrown when trying to serialize a graph to JSON-LD where a subject was a BlankNode. 

This pull-request fixes that issue and the unit test has been updated to cover this as well.