### PR TITLE
Anon node generation fixes

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -186,6 +186,9 @@ func (g *Graph) Parse(reader io.Reader, mime string) error {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(reader)
 		jsonData, err := jsonld.ReadJSON(buf.Bytes())
+		if err != nil {
+			return err
+		}
 		options := &jsonld.Options{}
 		options.Base = ""
 		options.ProduceGeneralizedRdf = false

--- a/graph_test.go
+++ b/graph_test.go
@@ -78,7 +78,7 @@ func TestGraphLiteralTerms(t *testing.T) {
 }
 
 func TestGraphBlankNodeTerms(t *testing.T) {
-	t1 := NewBlankNode(1)
+	t1 := NewBlankNode("n1")
 	assert.True(t, t1.Equal(rdf2term(term2rdf(t1))))
 	assert.True(t, t1.Equal(jterm2term(term2jterm(t1))))
 }
@@ -199,7 +199,7 @@ func TestSerializeJSONLD(t *testing.T) {
 	g := NewGraph(testUri)
 	g.Parse(strings.NewReader(simpleTurtle), "text/turtle")
 	g.Add(NewTriple(NewResource(testUri+"#me"), NewResource("http://xmlns.com/foaf/0.1/nick"), NewLiteralWithLanguage("test", "en")))
-	g.Add(NewTriple(NewBlankNode(9), NewResource("http://xmlns.com/foaf/0.1/name"), NewLiteralWithLanguage("test", "en")))
+	g.Add(NewTriple(NewBlankNode("n9"), NewResource("http://xmlns.com/foaf/0.1/name"), NewLiteralWithLanguage("test", "en")))
 	assert.Equal(t, 4, g.Len())
 
 	var b bytes.Buffer

--- a/term.go
+++ b/term.go
@@ -155,16 +155,16 @@ func NewBlankNode(id string) (term Term) {
 
 // NewAnonNode returns a new blank node with a pseudo-randomly generated ID.
 func NewAnonNode() (term Term) {
-	return Term(&BlankNode{ID: fmt.Sprint("_a:", rand.Int())})
+	return Term(&BlankNode{ID: fmt.Sprint("n", rand.Int())})
 }
 
 // String returns the NTriples representation of the blank node.
 func (term BlankNode) String() string {
-	return "_:" + fmt.Sprintf("%s", term.ID)
+	return "_:" + term.ID
 }
 
 func (term BlankNode) RawValue() string {
-	return fmt.Sprintf("%s", term.ID)
+	return term.ID
 }
 
 // Equal returns whether this blank node is equivalent to another.

--- a/term_test.go
+++ b/term_test.go
@@ -1,8 +1,9 @@
 package rdf2go
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type fakeTerm struct {
@@ -67,9 +68,9 @@ func TestTermNewLiteralWithDatatype(t *testing.T) {
 }
 
 func TestTermNewBlankNode(t *testing.T) {
-	id := NewBlankNode(1)
+	id := NewBlankNode("n1")
 	assert.Equal(t, "_:n1", id.String())
-	assert.Equal(t, "1", id.RawValue())
+	assert.Equal(t, "n1", id.RawValue())
 }
 
 func TestTermNewAnonNode(t *testing.T) {
@@ -79,10 +80,10 @@ func TestTermNewAnonNode(t *testing.T) {
 }
 
 func TestTermBNodeEqual(t *testing.T) {
-	id1 := NewBlankNode(1)
-	id2 := NewBlankNode(1)
+	id1 := NewBlankNode("n1")
+	id2 := NewBlankNode("n1")
 	assert.True(t, id1.Equal(id2))
-	id3 := NewBlankNode(2)
+	id3 := NewBlankNode("n2")
 	assert.False(t, id1.Equal(id3))
 	assert.False(t, id1.Equal(NewResource(testUri)))
 }
@@ -103,7 +104,7 @@ func TestAtLang(t *testing.T) {
 func TestEncodeTerm(t *testing.T) {
 	iterm := NewResource(testUri)
 	assert.Equal(t, iterm.String(), encodeTerm(iterm))
-	iterm = NewBlankNode(1)
+	iterm = NewBlankNode("n1")
 	assert.Equal(t, iterm.String(), encodeTerm(iterm))
 	iterm = NewLiteral("value")
 	assert.Equal(t, iterm.String(), encodeTerm(iterm))


### PR DESCRIPTION
I have fixed a couple of errors that appeared after the `ID` of a `BlankNode` was changed from int to string in #9. The `NewAnonNode` function was returning a `BlankNode` with its `ID` set to `"_a:"` followed by a random int. This caused the N3 representation of the node to be `_:_a:` followed by the random int, which is [not valid](https://www.w3.org/TR/rdf12-n-triples/#BNodes). `NewAnonNode` now returns a `BlankNode` with its `ID` formed by concatenating `"n"` to a random int.

I have also removed a couple of unnecesary calls to `fmt.Sprintf`, I have updated the tests to pass with the new changes and I have added a missing error handler when parsing a JSON-LD file.