### PR TITLE
Fix unescape

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/deiu/rdf2go
 go 1.23
 
 require (
-	github.com/deiu/gon3 v0.0.0-20230411081920-f0f8f879f597
+	github.com/deiu/gon3 v0.0.0-20241212124032-93153c038193
 	github.com/linkeddata/gojsonld v0.0.0-20170418210642-4f5db6791326
 	github.com/stretchr/testify v1.8.2
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deiu/rdf2go
 
-go 1.19
+go 1.23
 
 require (
 	github.com/deiu/gon3 v0.0.0-20230411081920-f0f8f879f597

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deiu/gon3 v0.0.0-20230411081920-f0f8f879f597 h1:xKCSqM+c9FjQIr0Qacn9m7x0kv/opDWGr/nvCowFCok=
-github.com/deiu/gon3 v0.0.0-20230411081920-f0f8f879f597/go.mod h1:r8Pv5x6dxChq4mb1ZqzTyK3y9w8wDzWt55XAJpfSq34=
-github.com/deiu/gon3 v0.0.0-20241129160627-433c36af8ac1 h1:UQu++NaENwt8fBd2hFQLwsDPrZpAV5hqsn9c4fFUIaM=
-github.com/deiu/gon3 v0.0.0-20241129160627-433c36af8ac1/go.mod h1:r8Pv5x6dxChq4mb1ZqzTyK3y9w8wDzWt55XAJpfSq34=
 github.com/deiu/gon3 v0.0.0-20241212124032-93153c038193 h1:EQBdXSCO7r+0KQE/pN6v+RAH7p6+yz+6pbCfHh+ETME=
 github.com/deiu/gon3 v0.0.0-20241212124032-93153c038193/go.mod h1:EdezkFZtCJELxMo+YIX5B5i5ofz9U+n+xSxWku6mOS0=
 github.com/linkeddata/gojsonld v0.0.0-20170418210642-4f5db6791326 h1:YP3lfXXYiQV5MKeUqVnxRP5uuMQTLPx+PGYm1UBoU98=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deiu/gon3 v0.0.0-20230411081920-f0f8f879f597 h1:xKCSqM+c9FjQIr0Qacn9m7x0kv/opDWGr/nvCowFCok=
 github.com/deiu/gon3 v0.0.0-20230411081920-f0f8f879f597/go.mod h1:r8Pv5x6dxChq4mb1ZqzTyK3y9w8wDzWt55XAJpfSq34=
+github.com/deiu/gon3 v0.0.0-20241129160627-433c36af8ac1 h1:UQu++NaENwt8fBd2hFQLwsDPrZpAV5hqsn9c4fFUIaM=
+github.com/deiu/gon3 v0.0.0-20241129160627-433c36af8ac1/go.mod h1:r8Pv5x6dxChq4mb1ZqzTyK3y9w8wDzWt55XAJpfSq34=
+github.com/deiu/gon3 v0.0.0-20241212124032-93153c038193 h1:EQBdXSCO7r+0KQE/pN6v+RAH7p6+yz+6pbCfHh+ETME=
+github.com/deiu/gon3 v0.0.0-20241212124032-93153c038193/go.mod h1:EdezkFZtCJELxMo+YIX5B5i5ofz9U+n+xSxWku6mOS0=
 github.com/linkeddata/gojsonld v0.0.0-20170418210642-4f5db6791326 h1:YP3lfXXYiQV5MKeUqVnxRP5uuMQTLPx+PGYm1UBoU98=
 github.com/linkeddata/gojsonld v0.0.0-20170418210642-4f5db6791326/go.mod h1:nfqkuSNlsk1bvti/oa7TThx4KmRMBmSxf3okHI9wp3E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Fixes #7 by updating the gon3 dependency to a new version that handles escaped escapes.